### PR TITLE
loader: fix link issue for lld(version >= 9)

### DIFF
--- a/loader/stage0/entry/linker.lds
+++ b/loader/stage0/entry/linker.lds
@@ -40,6 +40,8 @@ SECTIONS
     *(.stage0_runtime)
   } =0x90909090
 
+  . = .;
+
   /DISCARD/ :
   {
     /*


### PR DESCRIPTION
When use higher version(>=9) of lld, there will be link issue
as below:
    ld.lld: error: linker.lds:45: malformed number: :
    >>>   /DISCARD/ :
    >>>

This patch fix the issue by add an assign expression before
"/DISCARD/".

Signed-off-by: Qi Yadong <yadong.qi@intel.com>