### PR TITLE
loader: fix link issue for lld(version >= 9)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,6 @@ CFLAGS += -static -nostdinc
 # Disable implicit builtin knowledge of functions
 CFLAGS += -fno-builtin
 
-# Do not assume null pointer deference does not exist
-CFLAGS += -fno-delete-null-pointer-checks
-
 # Treat signed integer overflow as two’s complement
 CFLAGS += -fwrapv
 
@@ -91,6 +88,22 @@ CFLAGS += -funsigned-bitfields
 
 # Do not assume that signed overflow does not occur
 CFLAGS += -fno-strict-overflow
+
+# Do not assume null pointer deference does not exist
+CFLAGS += -fno-delete-null-pointer-checks
+
+else
+
+# Clang support "-fno-delete-null-pointer-checks flags" when (version > 6)
+MAJOR_VER := $(shell echo '$(CC_VERSION)' |\
+               head -1 |\
+               sed -n 's/.*clang version \([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/p' |\
+               head -c 1)
+
+ifeq ($(shell test $(MAJOR_VER) -gt 6; echo $$?), 0)
+CFLAGS += -fno-delete-null-pointer-checks
+endif
+
 endif
 
 AFLAGS = -c -m64 $(EVMM_CMPL_FLAGS) -fPIC -static -nostdinc

--- a/loader/stage0/entry/entry_64.S
+++ b/loader/stage0/entry/entry_64.S
@@ -195,7 +195,7 @@ stack_canary:
 	.quad 0
 #endif
 
-.section .stage0_runtime
+.section .stage0_runtime,"ax"
 .align 8
 stage0_runtime_base:
 	.fill STAGE0_RT_SIZE, 1, 0

--- a/loader/stage0/entry/linker.lds
+++ b/loader/stage0/entry/linker.lds
@@ -40,6 +40,8 @@ SECTIONS
     *(.stage0_runtime)
   } =0x90909090
 
+  . = .;
+
   /DISCARD/ :
   {
     /*


### PR DESCRIPTION
When use higher version(>=9) of lld, there will be link issue
as below:
    ld.lld: error: linker.lds:45: malformed number: :
    >>>   /DISCARD/ :
    >>>

This patch fix the issue by add an assign expression before
"/DISCARD/".

Signed-off-by: Qi Yadong <yadong.qi@intel.com>